### PR TITLE
Different UI options

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -72,6 +72,7 @@ public class RuneLite
 	public static final File RUNELITE_DIR = new File(System.getProperty("user.home"), ".runelite");
 	public static final File PROFILES_DIR = new File(RUNELITE_DIR, "profiles");
 	public static final File SCREENSHOT_DIR = new File(RUNELITE_DIR, "screenshots");
+	public static final File LOOT_RECORD_DIR = new File(RUNELITE_DIR, "loots");
 	private static final File LOGS_DIR = new File(RUNELITE_DIR, "logs");
 	private static final File LOGS_FILE_NAME = new File(LOGS_DIR, "application");
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerConfig.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2018, TheStonedTurtle <https://github.com/TheStonedTurtle>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.loottracker;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("loottracker")
+public interface LootTrackerConfig extends Config
+{
+	public enum ItemDisplays
+	{
+		GRID,
+		LIST
+	}
+
+	public enum MonsterDisplays
+	{
+		KILL_ORDER,
+		NAME,
+		ID
+	}
+
+	public enum Groupings
+	{
+		INDIVIDUAL,
+		CONSOLIDATED
+	}
+
+	@ConfigItem(
+			keyName = "monsterDisplaySetting",
+			name = "Monster Display",
+			description = "Configure how monster loot should be displayed inside the panel",
+			position = 0
+	)
+	default MonsterDisplays monsterDisplaySetting()
+	{
+		return MonsterDisplays.KILL_ORDER;
+	}
+
+	@ConfigItem(
+			keyName = "itemDisplaySetting",
+			name = "Item Display",
+			description = "Configure how items should be displayed inside the panel",
+			position = 1
+	)
+	default ItemDisplays itemDisplaySetting()
+	{
+		return ItemDisplays.GRID;
+	}
+
+	@ConfigItem(
+			keyName = "itemGroupingSetting",
+			name = "Item Grouping",
+			description = "Configure how items should be grouped inside the panel",
+			position = 2
+	)
+	default Groupings itemGroupingSetting()
+	{
+		return Groupings.INDIVIDUAL;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.loottracker;
 
 import com.google.common.eventbus.Subscribe;
 import java.awt.image.BufferedImage;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.regex.Matcher;
@@ -51,6 +52,7 @@ import net.runelite.client.game.ItemStack;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.loottracker.data.LootRecord;
+import net.runelite.client.plugins.loottracker.data.LootRecordWriter;
 import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.ui.PluginToolbar;
 import net.runelite.client.util.Text;
@@ -74,6 +76,8 @@ public class LootTrackerPlugin extends Plugin
 
 	@Inject
 	private LootTrackerConfig config;
+
+	private LootRecordWriter writer;
 
 	@Provides
 	LootTrackerConfig provideConfig(ConfigManager configManager)
@@ -105,6 +109,8 @@ public class LootTrackerPlugin extends Plugin
 			.build();
 
 		pluginToolbar.addNavigation(navButton);
+
+		writer = new LootRecordWriter(client);
 	}
 
 	@Override
@@ -120,6 +126,7 @@ public class LootTrackerPlugin extends Plugin
 		Collection<ItemStack> items = npcLootReceived.getItems();
 		LootRecord e = new LootRecord(npc.getId(), npc.getName(), npc.getCombatLevel(), -1, items);
 		SwingUtilities.invokeLater(() -> panel.addLootRecord(e));
+		writer.addData(npc.getName(), e);
 	}
 
 	@Subscribe
@@ -165,6 +172,7 @@ public class LootTrackerPlugin extends Plugin
 				}
 				LootRecord r = new LootRecord(-1, eventType, -1, -1, items);
 				SwingUtilities.invokeLater(() -> panel.addLootRecord(r));
+				writer.addData(eventType, r);
 			}
 			else
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/data/LootRecord.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/data/LootRecord.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2018, TheStonedTurtle <www.github.com/TheStonedTurtle>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.loottracker.data;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Getter;
+import net.runelite.client.game.ItemStack;
+
+public class LootRecord
+{
+	@Getter
+	private final int id;
+	@Getter
+	private final String name;
+	@Getter
+	private final int level;
+	@Getter
+	private final int killCount;
+	@Getter
+	final Collection<ItemStack> drops;
+
+	public LootRecord(int id, String name, int level, int kc, Collection<ItemStack> drops)
+	{
+		this.id = id;
+		this.name = name;
+		this.level = level;
+		this.killCount = kc;
+		this.drops = (drops == null ? new ArrayList<>() : drops);
+	}
+
+	/**
+	 * Add the requested ItemStack to this LootRecord
+	 * @param drop ItemStack to add
+	 */
+	public void addDropEntry(ItemStack drop)
+	{
+		drops.add(drop);
+	}
+
+	/**
+	 * Consolidates all LootRecords into a single LootRecord by `name`
+	 * This will combine the `drops` for all entries and sets the new record's killCount to -1
+	 * @param entries Collection of LootRecords to Consolidate
+	 * @return Collection of Consolidated LootRecords
+	 */
+	public static Collection<LootRecord> consolidateLootRecordsByName(Collection<LootRecord> entries)
+	{
+		Map<String, LootRecord> map = new HashMap<>();
+
+		for (LootRecord e : entries)
+		{
+			// Grab loot entry from map or create it. Don't pass drops to prevent duplicate adds
+			LootRecord entry = map.computeIfAbsent(e.getName(), v -> new LootRecord(e.getId(), e.getName(), e.getLevel(), -1, null));
+			entry.getDrops().addAll(e.getDrops());
+			map.put(e.getName(), entry);
+		}
+
+		return map.values();
+	}
+
+	/**
+	 * Consolidates all LootRecords into a single LootRecord by `id`
+	 * This will combine the `drops` for all entries and sets the new record's killCount to -1
+	 * @param entries Collection of LootRecords to Consolidate
+	 * @return Collection of Consolidated LootRecords
+	 */
+	public static Collection<LootRecord> consolidateLootRecordsById(Collection<LootRecord> entries)
+	{
+		Map<Integer, LootRecord> map = new HashMap<>();
+
+		for (LootRecord e : entries)
+		{
+			// Grab loot entry from map or create it. Don't pass drops to prevent duplicate adds
+			LootRecord entry = map.computeIfAbsent(e.getId(), v -> new LootRecord(e.getId(), e.getName(), e.getLevel(), -1, null));
+			entry.getDrops().addAll(e.getDrops());
+			map.put(e.getId(), entry);
+		}
+
+		return map.values();
+	}
+
+	/**
+	 * Consolidate all `drops` by item id and returns an updated LootRecord
+	 * @param r LootRecord to consolidate drops for
+	 * @return LootRecord with Consolidated drops
+	 */
+	public static LootRecord consildateDropEntries(LootRecord r)
+	{
+		LootRecord result = new LootRecord(r.getId(), r.getName(), r.getLevel(), r.getKillCount(), null);
+
+		Map<Integer, Integer> trueItems = new HashMap<>();
+		for (ItemStack i : r.getDrops())
+		{
+			int count = trueItems.computeIfAbsent(i.getId(), v -> 0);
+			trueItems.put(i.getId(), count + i.getQuantity());
+		}
+
+		for (Map.Entry<Integer, Integer> e : trueItems.entrySet())
+		{
+			result.addDropEntry(new ItemStack(e.getKey(), e.getValue()));
+		}
+
+		return result;
+	}
+
+	@Override
+	public String toString()
+	{
+		StringBuilder m = new StringBuilder();
+		m.append("LootRecord{id=")
+				.append(id)
+				.append(",name=")
+				.append(name)
+				.append(",killCount=")
+				.append(killCount)
+				.append(",drops=[");
+
+		boolean addComma = false;
+		for (ItemStack d : drops)
+		{
+			if (addComma)
+			{
+				m.append(",");
+			}
+
+			m.append(d.toString());
+			addComma = true;
+		}
+		m.append("]}");
+
+		return m.toString();
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/data/LootRecordWriter.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/data/LootRecordWriter.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2018, TheStonedTurtle <https://github.com/TheStonedTurtle>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.loottracker.data;
+
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.http.api.RuneLiteAPI;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static net.runelite.client.RuneLite.LOOT_RECORD_DIR;
+
+@Slf4j
+public class LootRecordWriter
+{
+	private static final String FILE_EXTENSION = ".log";
+
+	private Client client;
+	// Data is stored in a folder with the players in-game username
+	private File playerFolder;
+	// Record of existing .log files
+	private Map<String, File> fileMap = new HashMap<>();
+
+	public LootRecordWriter(Client client)
+	{
+		this.client = client;
+
+		LOOT_RECORD_DIR.mkdir();
+
+		// Ensure playerFolder is up to date.
+		updatePlayerFolder();
+
+		// Create fileMap
+		File[] files = playerFolder.listFiles((dir, name) -> name.endsWith(".log"));
+		for (File f : files)
+		{
+
+			fileMap.put(f.getName(), f);
+			log.debug("Found log file: {}", f.getName());
+		}
+	}
+
+	private void updatePlayerFolder()
+	{
+		if (client.getLocalPlayer() != null && client.getLocalPlayer().getName() != null)
+		{
+			playerFolder = new File(LOOT_RECORD_DIR, client.getLocalPlayer().getName());
+		}
+		else
+		{
+			playerFolder = LOOT_RECORD_DIR;
+		}
+
+		playerFolder.mkdir();
+	}
+
+	private File getOrCreateFile(String fileName)
+	{
+		File req = fileMap.get(fileName);
+		if (req == null)
+		{
+			req = new File(playerFolder, fileName);
+			fileMap.put(fileName, req);
+		}
+
+		return req;
+	}
+
+	private String npcNameToFileName(String npcName)
+	{
+		return npcName.toLowerCase().trim() + FILE_EXTENSION;
+	}
+
+	private synchronized Collection<LootRecord> loadLootRecords(String npcName)
+	{
+		String fileName = npcNameToFileName(npcName);
+		File file = getOrCreateFile(fileName);
+
+		try (BufferedReader br = new BufferedReader(new FileReader(file)))
+		{
+			Collection<LootRecord> data = new ArrayList<>();
+
+			String line;
+			while ((line = br.readLine()) != null)
+			{
+				if (line.length() > 0)
+				{
+					LootRecord r = RuneLiteAPI.GSON.fromJson(line, LootRecord.class);
+					data.add(r);
+				}
+			}
+
+			return data;
+		}
+		catch (FileNotFoundException e)
+		{
+			log.debug("File not found: {}", fileName);
+			return null;
+		}
+		catch (IOException e)
+		{
+			log.warn("IOException for file {}: {}", fileName, e.getMessage());
+			return null;
+		}
+	}
+
+	// Add Loot Entry to the necessary file
+	private synchronized boolean addLootEntry(String npcName, LootRecord rec)
+	{
+		// Convert entry to JSON
+		String dataAsString = RuneLiteAPI.GSON.toJson(rec);
+
+		// Grab file
+		String fileName = npcNameToFileName(npcName);
+		File lootFile = getOrCreateFile(fileName);
+
+		// Open File in append mode and write new data
+		try
+		{
+			BufferedWriter file = new BufferedWriter(new FileWriter(String.valueOf(lootFile), true));
+			file.append(dataAsString);
+			file.newLine();
+			file.close();
+			return true;
+		}
+		catch (IOException ioe)
+		{
+			log.warn("Error writing loot data to file {}: {}", fileName, ioe.getMessage());
+			return false;
+		}
+	}
+
+	// Mostly used to adjust previous loot entries (adding pet drops)
+	private boolean rewriteLootFile(String npcName, Collection<LootRecord> loots)
+	{
+		String fileName = npcNameToFileName(npcName);
+		File lootFile = getOrCreateFile(fileName);
+
+		// Rewrite the log file (to update the last loot entry)
+		try
+		{
+			BufferedWriter file = new BufferedWriter(new FileWriter(String.valueOf(lootFile), false));
+			for ( LootRecord rec : loots)
+			{
+				// Convert entry to JSON
+				String dataAsString = RuneLiteAPI.GSON.toJson(rec);
+				file.append(dataAsString);
+				file.newLine();
+			}
+			file.close();
+
+			return true;
+		}
+		catch (IOException ioe)
+		{
+			log.warn("Error rewriting loot data to file {}: {}", fileName, ioe.getMessage());
+			return false;
+		}
+	}
+
+	// Delete log file for specified npc name
+	private synchronized boolean clearLogFile(String npcName)
+	{
+		String fileName = npcNameToFileName(npcName);
+
+		File lootFile = new File(playerFolder, fileName);
+
+		if (lootFile.delete())
+		{
+			log.debug("Deleted loot file: {}", fileName);
+			return true;
+		}
+		else
+		{
+			log.debug("Couldn't delete file: {}", fileName);
+			return false;
+		}
+	}
+
+	// Public Wrappers
+	public Collection<LootRecord> loadData(String npcName)
+	{
+		return loadLootRecords(npcName);
+	}
+
+	public boolean addData(String npcName, LootRecord rec)
+	{
+		return addLootEntry(npcName, rec);
+	}
+
+	public boolean rewriteData(String npcName, Collection<LootRecord> loot)
+	{
+		return rewriteLootFile(npcName, loot);
+	}
+
+	public boolean clearData(String npcName)
+	{
+		return clearLogFile(npcName);
+	}
+
+	public Set<String> getKnownFileNames()
+	{
+		return fileMap.keySet();
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/ui/ItemGridPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/ui/ItemGridPanel.java
@@ -33,7 +33,6 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
-import java.awt.Dimension;
 import java.awt.GridLayout;
 
 public class ItemGridPanel extends JPanel
@@ -42,14 +41,13 @@ public class ItemGridPanel extends JPanel
 
 	public ItemGridPanel(ItemStack[] items, ItemManager itemManager)
 	{
-		int rowSize = (items.length / ITEMS_PER_ROW) + 1;
+		int rowSize = ((items.length % ITEMS_PER_ROW == 0) ? 0 : 1) + items.length / ITEMS_PER_ROW;
 
-		this.setLayout(new GridLayout(rowSize, ITEMS_PER_ROW));
+		this.setLayout(new GridLayout(rowSize, ITEMS_PER_ROW, 1, 1));
 
 		for (int i = 0; i < rowSize * ITEMS_PER_ROW; i++)
 		{
 			JPanel slotContainer = new JPanel();
-			slotContainer.setPreferredSize(new Dimension(40, 40));
 			slotContainer.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 
 			if (i < items.length)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/ui/ItemGridPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/ui/ItemGridPanel.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2018, TheStonedTurtle <https://github.com/TheStonedTurtle>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.loottracker.ui;
+
+import net.runelite.client.game.AsyncBufferedImage;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.game.ItemStack;
+import net.runelite.client.ui.ColorScheme;
+import javax.swing.ImageIcon;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
+import java.awt.Dimension;
+import java.awt.GridLayout;
+
+public class ItemGridPanel extends JPanel
+{
+	private static final int ITEMS_PER_ROW = 5;
+
+	public ItemGridPanel(ItemStack[] items, ItemManager itemManager)
+	{
+		int rowSize = (items.length / ITEMS_PER_ROW) + 1;
+
+		this.setLayout(new GridLayout(rowSize, ITEMS_PER_ROW));
+
+		for (int i = 0; i < rowSize * ITEMS_PER_ROW; i++)
+		{
+			JPanel slotContainer = new JPanel();
+			slotContainer.setPreferredSize(new Dimension(40, 40));
+			slotContainer.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+
+			if (i < items.length)
+			{
+				ItemStack item = items[i];
+
+				AsyncBufferedImage icon = itemManager.getImage(item.getId(), item.getQuantity(), item.getQuantity() > 1);
+				Runnable addImage = () ->
+				{
+					SwingUtilities.invokeLater(() ->
+					{
+						JLabel imageLabel = new JLabel(new ImageIcon(icon));
+						imageLabel.setVerticalAlignment(SwingConstants.CENTER);
+						imageLabel.setHorizontalAlignment(SwingConstants.CENTER);
+
+						slotContainer.add(imageLabel);
+						slotContainer.revalidate();
+						slotContainer.repaint();
+					});
+				};
+				icon.onChanged(addImage);
+				addImage.run();
+			}
+
+			this.add(slotContainer);
+		}
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/ui/ItemStackPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/ui/ItemStackPanel.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2018, TheStonedTurtle <https://github.com/TheStonedTurtle>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.loottracker.ui;
+
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+import javax.swing.border.EmptyBorder;
+import lombok.Getter;
+import net.runelite.api.ItemComposition;
+import net.runelite.api.ItemID;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.game.ItemStack;
+import net.runelite.client.ui.ColorScheme;
+import net.runelite.client.ui.FontManager;
+import net.runelite.client.ui.components.shadowlabel.JShadowedLabel;
+import net.runelite.client.util.StackFormatter;
+import net.runelite.http.api.item.ItemPrice;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.GridLayout;
+
+@Getter
+public class ItemStackPanel extends JPanel
+{
+	private ItemStack item;
+	private ItemComposition comp;
+	private int value;
+
+	public ItemStackPanel(ItemStack item, ItemManager itemManager)
+	{
+		this.item = item;
+		this.comp = itemManager.getItemComposition(item.getId());
+		ItemPrice p = itemManager.getItemPrice(item.getId());
+		int v = p != null ? p.getPrice() : 0;
+		this.value = v >= 0 ? v : 0;
+		if (item.getId() == ItemID.COINS_995)
+		{
+			this.value = 1;
+		}
+
+		this.setLayout(new GridBagLayout());
+		this.setBorder(new EmptyBorder(3, 0, 3, 0));
+		this.setBackground(ColorScheme.DARK_GRAY_COLOR);
+
+		// Item Image Icon
+		JLabel icon = new JLabel();
+		itemManager.getImage(item.getId(), item.getQuantity(), item.getQuantity() > 1 || comp.isStackable()).addTo(icon);
+		icon.setHorizontalAlignment(JLabel.CENTER);
+
+		// Container for Info
+		JPanel uiInfo = new JPanel(new GridLayout(2, 1));
+		uiInfo.setBorder(new EmptyBorder(0, 5, 0, 0));
+		uiInfo.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+
+		JShadowedLabel labelName = new JShadowedLabel(comp.getName());
+		labelName.setForeground(Color.WHITE);
+		colorLabel(labelName, this.value);
+		labelName.setVerticalAlignment(SwingUtilities.BOTTOM);
+
+		int total = value * item.getQuantity();
+		JShadowedLabel labelValue = new JShadowedLabel(StackFormatter.quantityToStackSize(total) + " gp");
+		labelValue.setFont(FontManager.getRunescapeSmallFont());
+		colorLabel(labelValue, total);
+		labelValue.setVerticalAlignment(SwingUtilities.TOP);
+
+		uiInfo.add(labelName);
+		uiInfo.add(labelValue);
+
+		// Create and append elements to container panel
+		JPanel panel = new JPanel();
+		panel.setLayout(new BorderLayout());
+		panel.setBorder(new EmptyBorder(0, 15, 0, 15));
+		panel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+
+		panel.add(icon, BorderLayout.LINE_START);
+		panel.add(uiInfo, BorderLayout.CENTER);
+
+		GridBagConstraints c = new GridBagConstraints();
+		c.fill = GridBagConstraints.BOTH;
+		c.weightx = 1;
+		c.gridx = 0;
+		c.gridy = 0;
+		c.ipady = 20;
+
+		this.add(panel, c);
+	}
+
+	// Color label to match RuneScape coloring
+	private void colorLabel(JLabel label, long val)
+	{
+		Color labelColor = (val >= 10000000) ? Color.GREEN : (val >= 100000) ? Color.WHITE : Color.YELLOW;
+		label.setForeground(labelColor);
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/ui/LootRecordPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/ui/LootRecordPanel.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2018, TheStonedTurtle <https://github.com/TheStonedTurtle>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.loottracker.ui;
+
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.game.ItemStack;
+import net.runelite.client.plugins.loottracker.LootTrackerConfig;
+import net.runelite.client.plugins.loottracker.data.LootRecord;
+import net.runelite.client.ui.ColorScheme;
+import net.runelite.client.ui.FontManager;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.border.EmptyBorder;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.GridLayout;
+
+public class LootRecordPanel extends JPanel
+{
+	public LootRecordPanel(LootRecord record, ItemManager itemManager, LootTrackerConfig config)
+	{
+		String npcName = record.getName();
+		int npcLevel = record.getLevel();
+		ItemStack[] items = record.getDrops().toArray(new ItemStack[0]);
+
+		this.setLayout(new BorderLayout(0, 1));
+
+		JPanel logTitle = new JPanel(new BorderLayout(5, 0));
+		logTitle.setBorder(new EmptyBorder(7, 7, 7, 7));
+		logTitle.setBackground(ColorScheme.DARKER_GRAY_COLOR.darker());
+
+		JLabel npcNameLabel = new JLabel(npcName);
+		npcNameLabel.setFont(FontManager.getRunescapeSmallFont());
+		npcNameLabel.setForeground(Color.WHITE);
+
+		logTitle.add(npcNameLabel, BorderLayout.WEST);
+
+		// For events outside of npc drops (barrows, raids, etc) the level should be -1
+		if (npcLevel > -1)
+		{
+			JLabel npcLevelLabel = new JLabel("(lvl. " + npcLevel + ")");
+			npcLevelLabel.setFont(FontManager.getRunescapeSmallFont());
+			npcLevelLabel.setForeground(ColorScheme.LIGHT_GRAY_COLOR);
+
+			logTitle.add(npcLevelLabel, BorderLayout.CENTER);
+		}
+
+		JPanel content;
+		if (config.itemDisplaySetting() == LootTrackerConfig.ItemDisplays.GRID)
+		{
+			content = new ItemGridPanel(items, itemManager);
+		}
+		else
+		{
+			content = new JPanel(new GridLayout(0, 1, 0, 10));
+			for (ItemStack s : items)
+			{
+				content.add(new ItemStackPanel(s, itemManager));
+			}
+		}
+
+		this.add(logTitle, BorderLayout.NORTH);
+		this.add(content, BorderLayout.CENTER);
+	}
+}


### PR DESCRIPTION

Added `LootRecord` class to help with storing and consolidating all types of Loot Events.
Moved code for creating Log header information from `LootTrackerPanel` to `LootRecordPanel`.
Moved code for creating Items in Grid Box from `LootTrackerPanel` to `ItemGridPanel`.
Added `ItemStackPanel` which is used to display an Individual `ItemStack`:
![](https://i.imgur.com/6txNmzN.png)
Added config file with ability to select certain display settings.

These are mostly proof of concepts, feel free to pull any code you might need, if any.